### PR TITLE
fix(detector): initialize FusionContinuousDetector with configured timing

### DIFF
--- a/src/pymxbi/mxbi/factory.py
+++ b/src/pymxbi/mxbi/factory.py
@@ -86,7 +86,12 @@ def _make_detector(config: DetectorModel) -> Detector:
         case DetectorEnum.FUSION_CONTINUOUS:
             rfid_reader = DorsetLID665v42(config.port, config.baudrate)
             sensor = RPIIRBreakBeamSensor(config.pin)
-            return FusionContinuousDetector(rfid_reader, sensor)
+            return FusionContinuousDetector(
+                rfid_reader,
+                sensor,
+                poll_interval=config.poll_interval,
+                rfid_timeout=config.rfid_timeout,
+            )
 
         case _:
             raise ValueError(f"Unknown detector type: {config.type}")


### PR DESCRIPTION
## Summary
- Apply the detector initialization fix by passing configured `poll_interval` and `rfid_timeout` into `FusionContinuousDetector`.
- Ensure runtime detector timing uses values from config instead of constructor defaults.
- Exclude unrelated audioplayer changes by cherry-picking only the detector fix commit.